### PR TITLE
Fixed failing grunt test in master

### DIFF
--- a/module.js
+++ b/module.js
@@ -32,7 +32,6 @@ function (_, sdk, kbn, TimeSeries, rendering) {
     nullPointMode: 'connected'
   };
 
-
   var PieChartCtrl = (function(_super) {
 
     function PieChartCtrl($scope, $injector, $rootScope) {


### PR DESCRIPTION
If we copy this plugin into Grafana master and run "grunt test", this extra line fails the grunt test.